### PR TITLE
Configure Travis ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+


### PR DESCRIPTION
 ### What is the goal?
Configure travis Ci , a hosted continuous integration service used to build and test the project hosted on GitHub.

 ### Definition of done

1. [x] Continuous Integration
1. [x] test the project hosted on branch.

 ### How is it being implemented?
Creating circleci config repository( .circleci/config.yml)

 ### Opportunistic refactorings
NA
